### PR TITLE
Update the ubuntu version name

### DIFF
--- a/add-apt-repository.sh
+++ b/add-apt-repository.sh
@@ -13,7 +13,7 @@ then
 	echo "$0 ppa:user/ppa-name"
 else
 	echo "$ppa_name"
-	echo "deb http://ppa.launchpad.net/$ppa_name/ubuntu lucid main" >> /etc/apt/sources.list
+	echo "deb http://ppa.launchpad.net/$ppa_name/ubuntu eoan main" >> /etc/apt/sources.list
 	apt-get update >> /dev/null 2> /tmp/${NAME}_apt_add_key.txt
 	key=`cat /tmp/${NAME}_apt_add_key.txt | cut -d":" -f6 | cut -d" " -f3`
 	apt-key adv --keyserver keyserver.ubuntu.com --recv-keys $key


### PR DESCRIPTION
I was trying to use the script, but was getting me an error

```
E: The repository 'http://ppa.launchpad.net/graphics-drivers/ubuntu lucid Release' does not have a Release file.
N: Updating from such a repository can't be done securely, and is therefore disabled by default.
N: See apt-secure(8) manpage for repository creation and user configuration details.
```

So, I look it up and I update the ``lucid`` ubuntu version to ``eoan`` and fix it